### PR TITLE
Develop complete fleet management system

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -84,4 +84,12 @@ function generateMaintenanceNotifications(PDO $pdo)
 
 // Run generator once per request (after DB connection ready)
 generateMaintenanceNotifications($pdo);
+
+if(!function_exists('get_setting')){
+function get_setting(PDO $pdo,$key){
+  static $stm=null;
+  if(!$stm){$stm=$pdo->prepare('SELECT value FROM settings WHERE `key`=? LIMIT 1');}
+  $stm->execute([$key]);
+  return $stm->fetchColumn();
+}}
 ?>


### PR DESCRIPTION
Add `get_setting()` helper function to resolve "undefined function" error and enable conditional display of GPS cards.

Commit `df7c437` introduced a fatal error on `modules/vehicles/index.php` because the `get_setting()` function, used to conditionally display GPS cards based on tracking API activation, was not globally defined. This commit makes the function available for all pages that need to retrieve settings from the database.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-671f8475-5a60-4ec0-aad4-bbb8c3fe9061) · [Cursor](https://cursor.com/background-agent?bcId=bc-671f8475-5a60-4ec0-aad4-bbb8c3fe9061)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)